### PR TITLE
Update base image to openjdk:8u121-jre-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u111-jre-alpine
+FROM openjdk:8u121-jre-alpine
 
 ENV KAFKA_VERSION=0.10.2.0 \
     SCALA_VERSION=2.12 \


### PR DESCRIPTION
Update the base image from openjdk:8u111-jre-alpine to
openjdk:8u121-jre-alpine. The 8u121-jre-alpine tag notably upgrades
alpine from 3.4 to 3.5.